### PR TITLE
create object directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+ODIR = bin
+   side_effect_heir := $(shell mkdir -p $(ODIR))
+
 make:
 	g++ -pthread -std=c++11 *.cpp -o bin/buddhabrotter
 


### PR DESCRIPTION
If there is no `bin` directory, `make` fails. Tell `Makefile` to make a `bin` directory before invoking the compiler.